### PR TITLE
removed [cli] in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GQLSpection is available on PyPI (Python 2.7 and Python 3+ versions are supporte
 Regular installation:
 
 ```bash
-$ pip install gqlspection[cli]
+$ pip install gqlspection
 ```
 
 ## Usage of the CLI tool


### PR DESCRIPTION
While trying to install it on my mac, i've been faced with the error 


```
zsh: no matches found: gqlspection[cli]
```

To fix this issue, i had to remove `[cli]` from the install command. 




Is this an issue on my end, or a genuine error? 